### PR TITLE
Add urgency and app_name arguemnts to Linux notify-send.

### DIFF
--- a/src/linux.jl
+++ b/src/linux.jl
@@ -9,15 +9,24 @@ include("email.jl")
 Notify by desktop notification.
 
 # Arguments
+- `urgency::AbstractString` : Urgency level ("low", "normal", "critical"). Default is "normal".
 - `sound::Union{Bool, AbstractString}`: Play default sound or specific sound.
-- `time::Real`: display time.
+- `time::Real`: Display time.
 - `logo`: Default is Julia logo
+- `app_name::AbstractString` : Name of application sending the notification. Default is the name of your script (e.g. "test.jl") or "Julia REPL"/"Atom Juno" if using any of these two.
 """
 function notify(message::AbstractString;
                 title="Julia",
+                urgency::AbstractString="normal",
                 sound::Union{Bool, AbstractString}=false,
                 time::Real=4,
+                app_name::AbstractString=PROGRAM_FILE,
                 logo::AbstractString=joinpath(@__DIR__, "logo.svg"))
+    if app_name == "" && occursin("REPL", @__FILE__)    # Default for running in REPL
+        app_name = "Julia REPL"
+    elseif occursin("atom", app_name)                   # Default for running in Juno
+        app_name = "Atom Juno"
+    end
     if sound == true || typeof(sound) <: AbstractString
         if sound == true
             d = @__DIR__
@@ -26,7 +35,7 @@ function notify(message::AbstractString;
             @async run(`aplay -q $sound`)
         end
     end
-    run(`notify-send $title $message -i $(logo) -t $(time * 1000)`)
+    run(`notify-send $title $message -u $urgency -a $app_name -i $(logo) -t $(time * 1000)`)
 
     return
 end

--- a/src/linux.jl
+++ b/src/linux.jl
@@ -56,7 +56,15 @@ end
     Notifier.say(message::AbstractString)
 
 Read a given message aloud.
+
+# Arguments
+- `backend::AbstractString` : a CLI test-to-speech program used to synthesize speech ("espreak","festival")
 """
-function say(msg::AbstractString)
-    run(pipeline(`espeak $msg`, stderr=devnull))
+function say(msg::AbstractString;
+            backend::AbstractString="espeak")
+    if backend == "espeak"
+        run(pipeline(`espeak $msg`, stderr=devnull))
+    elseif backend == "festival"
+        run(pipeline(`echo $msg`, `festival --tts`))
+    end
 end

--- a/src/linux.jl
+++ b/src/linux.jl
@@ -14,7 +14,6 @@ Notify by desktop notification.
 - `time::Real`: Display time.
 - `logo`: Default is Julia logo
 - `app_name::AbstractString` : Name of application sending the notification. Default is the name of your script (e.g. "test.jl") or "Julia REPL"/"Atom Juno" if using any of these two.
-- `sound_backend::AbstractString` : a CLI audio program used ("aplay","sox","vlc")
 """
 function notify(message::AbstractString;
                 title="Julia",
@@ -22,8 +21,7 @@ function notify(message::AbstractString;
                 sound::Union{Bool, AbstractString}=false,
                 time::Real=4,
                 app_name::AbstractString=PROGRAM_FILE,
-                logo::AbstractString=joinpath(@__DIR__, "logo.svg"),
-                sound_backend::AbstractString="aplay")
+                logo::AbstractString=joinpath(@__DIR__, "logo.svg"))
     if app_name == "" && occursin("REPL", @__FILE__)   # Default for running in REPL
         app_name = "Julia REPL"
     elseif occursin("atom", app_name) && occursin("boot_repl.jl", app_name)  # Default for running in Juno
@@ -31,9 +29,10 @@ function notify(message::AbstractString;
     end
     if sound == true || typeof(sound) <: AbstractString
         if sound == true
-            alarm(backend=sound_backend)
+            d = @__DIR__
+            @async run(`aplay -q $(joinpath(d, "default.wav"))`)
         elseif ispath(sound)
-            alarm(sound=sound, backend=sound_backend)
+            @async run(`aplay -q $sound`)
         end
     end
     run(`notify-send $title $message -u $urgency -a $app_name -i $(logo) -t $(time * 1000)`)
@@ -47,19 +46,9 @@ notify() = notify("Task completed.")
 
 Notify by sound.
 If you choose a specific sound WAV file, you can play it instead of the default sound.
-
-# Arguments
-- `backend::AbstractString` : a CLI audio program used ("aplay","sox","vlc")
 """
-function alarm(;sound::AbstractString=joinpath(@__DIR__, "default.wav"),
-                backend::AbstractString="aplay")
-    if backend == "aplay"
-        @async run(`aplay -q $sound`)
-    elseif backend == "sox"
-        @async run(`play -q $sound`)
-    elseif backend == "vlc"
-        @async run(`cvlc --play-and-exit --no-loop $sound 2> /dev/null`)
-    end
+function alarm(;sound::AbstractString=joinpath(@__DIR__, "default.wav"))
+    @async run(`aplay -q $sound`)
     return nothing
 end
 

--- a/src/linux.jl
+++ b/src/linux.jl
@@ -14,6 +14,7 @@ Notify by desktop notification.
 - `time::Real`: Display time.
 - `logo`: Default is Julia logo
 - `app_name::AbstractString` : Name of application sending the notification. Default is the name of your script (e.g. "test.jl") or "Julia REPL"/"Atom Juno" if using any of these two.
+- `sound_backend::AbstractString` : a CLI audio program used ("aplay","sox","vlc")
 """
 function notify(message::AbstractString;
                 title="Julia",
@@ -21,7 +22,8 @@ function notify(message::AbstractString;
                 sound::Union{Bool, AbstractString}=false,
                 time::Real=4,
                 app_name::AbstractString=PROGRAM_FILE,
-                logo::AbstractString=joinpath(@__DIR__, "logo.svg"))
+                logo::AbstractString=joinpath(@__DIR__, "logo.svg"),
+                sound_backend::AbstractString="aplay")
     if app_name == "" && occursin("REPL", @__FILE__)   # Default for running in REPL
         app_name = "Julia REPL"
     elseif occursin("atom", app_name) && occursin("boot_repl.jl", app_name)  # Default for running in Juno
@@ -29,10 +31,9 @@ function notify(message::AbstractString;
     end
     if sound == true || typeof(sound) <: AbstractString
         if sound == true
-            d = @__DIR__
-            @async run(`aplay -q $(joinpath(d, "default.wav"))`)
+            alarm(backend=sound_backend)
         elseif ispath(sound)
-            @async run(`aplay -q $sound`)
+            alarm(sound=sound, backend=sound_backend)
         end
     end
     run(`notify-send $title $message -u $urgency -a $app_name -i $(logo) -t $(time * 1000)`)
@@ -46,9 +47,19 @@ notify() = notify("Task completed.")
 
 Notify by sound.
 If you choose a specific sound WAV file, you can play it instead of the default sound.
+
+# Arguments
+- `backend::AbstractString` : a CLI audio program used ("aplay","sox","vlc")
 """
-function alarm(;sound::AbstractString=joinpath(@__DIR__, "default.wav"))
-    @async run(`aplay -q $sound`)
+function alarm(;sound::AbstractString=joinpath(@__DIR__, "default.wav"),
+                backend::AbstractString="aplay")
+    if backend == "aplay"
+        @async run(`aplay -q $sound`)
+    elseif backend == "sox"
+        @async run(`play -q $sound`)
+    elseif backend == "vlc"
+        @async run(`cvlc --play-and-exit --no-loop $sound 2> /dev/null`)
+    end
     return nothing
 end
 

--- a/src/linux.jl
+++ b/src/linux.jl
@@ -22,9 +22,9 @@ function notify(message::AbstractString;
                 time::Real=4,
                 app_name::AbstractString=PROGRAM_FILE,
                 logo::AbstractString=joinpath(@__DIR__, "logo.svg"))
-    if app_name == "" && occursin("REPL", @__FILE__)    # Default for running in REPL
+    if app_name == "" && occursin("REPL", @__FILE__)   # Default for running in REPL
         app_name = "Julia REPL"
-    elseif occursin("atom", app_name)                   # Default for running in Juno
+    elseif occursin("atom", app_name) && occursin("boot_repl.jl", app_name)  # Default for running in Juno
         app_name = "Atom Juno"
     end
     if sound == true || typeof(sound) <: AbstractString


### PR DESCRIPTION
I've felt these two were missing, since sometimes I'd like to have several programs sending notifications. Then it's nice to have them distinguishable. Plus I didn't like the headline saying "notify-send", so I've changed it to something sounding more reasonable to me: a script name if running as a script or one of: Julia REPL, Atom Juno if running interactively. That part is kinda messy, I admit.
Similarly added urgency - especially useful if you have "Do not disturb mode" on, blocking non-critical notifications.